### PR TITLE
Added the tooltip items and graph data arguments to the custom toolti…

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -325,7 +325,7 @@ module.exports = function(Chart) {
 			}
 
 			if (changed && opts.custom) {
-				opts.custom.call(me, model);
+				opts.custom.call(me, model, tooltipItems, data);
 			}
 
 			return me;


### PR DESCRIPTION
I encountered an issue where I could not connect the data from the points to the graph data in my custom tooltip. This change allows a developer to make those connections and have all the data needed to fully describe the point(s) clicked.